### PR TITLE
Improve regex to handle more cases

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ module.exports = class CSSGeorgePlugin {
 
                 if (this.options.fallback) {
                     css = css.replace(/^.*var\(.*\).*$/mg, function(line) {
-                        return line.replace(/var\(.+?,\W?(.+?(?=\)))\)/g, '$1') + '\n' + line;
+                        return line.replace(/var\(.+?,\W?(.+?(?=\))(?!\){2,}))\)/g, '$1') + '\n' + line;
                     });
                 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ module.exports = class CSSGeorgePlugin {
 
                 if (this.options.fallback) {
                     css = css.replace(/^.*var\(.*\).*$/mg, function(line) {
-                        return line.replace(/var\(.+,\W?(.+)\)/, '$1') + '\n' + line;
+                        return line.replace(/var\(.+?,\W?(.+?(?=\)))\)/g, '$1') + '\n' + line;
                     });
                 }
 


### PR DESCRIPTION
- Lazily match commas, so `var(--foo, rgba(0, 0, 0, 0.25));` does not grab between the last comma and last bracket.
`0.25);` => `rgba(0, 0, 0, 0.25);`
- Use forward look-ahead and the global flag to stop at the first ending bracket, allowing rules that contain multiple variables.  e.g. `rgba(var(--red, 1.0), var(--green, 0.5), 1.0, 0.25);`
  - Paired with a negative forward look-ahead to not stop when there are two ending brackets (indicates that one of the brackets is part of the variable value)